### PR TITLE
Implement portal

### DIFF
--- a/packages/react-native-oursky-example/src/App.js
+++ b/packages/react-native-oursky-example/src/App.js
@@ -44,7 +44,7 @@ const AppNavigator = createDrawerNavigator(
 
 const AppContainer = createAppContainer(AppNavigator);
 
-export default class App extends React.Component {
+export default class App extends React.Component<{}> {
   render() {
     return (
       <PortalHost>

--- a/packages/react-native-oursky-example/src/App.js
+++ b/packages/react-native-oursky-example/src/App.js
@@ -1,9 +1,23 @@
 // @flow
-import { createAppContainer, createDrawerNavigator } from "react-navigation";
+import * as React from "react";
+import {
+  createAppContainer,
+  createDrawerNavigator,
+  createStackNavigator,
+} from "react-navigation";
+import { PortalHost } from "@oursky/react-native-oursky";
+
 import SignupWithMobileScreen from "./screens/SignupWithMobileScreen";
 import VerifyOTPScreen from "./screens/VerifyOTPScreen";
 import DialogScreen from "./screens/DialogScreen";
 import RequirePermissionScreen from "./screens/RequirePermissionScreen";
+import PortalScreen from "./screens/PortalScreen";
+
+const PortalScreenStackNavigator = createStackNavigator({
+  PortalScreen: {
+    screen: PortalScreen,
+  },
+});
 
 const AppNavigator = createDrawerNavigator(
   {
@@ -19,10 +33,23 @@ const AppNavigator = createDrawerNavigator(
     RequirePermission: {
       screen: RequirePermissionScreen,
     },
+    PortalScreenStackNavigator: {
+      screen: PortalScreenStackNavigator,
+    },
   },
   {
     initialRouteName: "SignupWithMobile",
   }
 );
 
-export default createAppContainer(AppNavigator);
+const AppContainer = createAppContainer(AppNavigator);
+
+export default class App extends React.Component {
+  render() {
+    return (
+      <PortalHost>
+        <AppContainer />
+      </PortalHost>
+    );
+  }
+}

--- a/packages/react-native-oursky-example/src/screens/PortalScreen.js
+++ b/packages/react-native-oursky-example/src/screens/PortalScreen.js
@@ -65,6 +65,7 @@ export default class PortalScreen extends React.PureComponent<{}, State> {
               >
                 <Text>Add 1</Text>
               </TouchableOpacity>
+              <Text>Count in portla: {this.state.count}</Text>
               <TouchableOpacity style={styles.button} onPress={this.hidePortal}>
                 <Text>Close</Text>
               </TouchableOpacity>

--- a/packages/react-native-oursky-example/src/screens/PortalScreen.js
+++ b/packages/react-native-oursky-example/src/screens/PortalScreen.js
@@ -1,0 +1,77 @@
+// @flow
+import * as React from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { Portal } from "@oursky/react-native-oursky";
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  portalContainer: {
+    backgroundColor: "rgba(0, 0, 0, 0.2)",
+    ...StyleSheet.absoluteFillObject,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  button: {
+    padding: 14,
+    backgroundColor: "red",
+    margin: 10,
+  },
+});
+
+type State = {
+  count: number,
+  showPortal: boolean,
+};
+
+export default class PortalScreen extends React.PureComponent<{}, State> {
+  state = {
+    count: 0,
+    showPortal: false,
+  };
+
+  showPortal = () => {
+    this.setState({
+      showPortal: true,
+    });
+  };
+
+  hidePortal = () => {
+    this.setState({
+      showPortal: false,
+    });
+  };
+
+  changeCount = () => {
+    this.setState(prevState => ({
+      count: prevState.count + 1,
+    }));
+  };
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <TouchableOpacity style={styles.button} onPress={this.showPortal}>
+          <Text>Press me</Text>
+        </TouchableOpacity>
+        <Text>Count: {this.state.count}</Text>
+        {this.state.showPortal && (
+          <Portal>
+            <View style={styles.portalContainer}>
+              <TouchableOpacity
+                style={styles.button}
+                onPress={this.changeCount}
+              >
+                <Text>Add 1</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={styles.button} onPress={this.hidePortal}>
+                <Text>Close</Text>
+              </TouchableOpacity>
+            </View>
+          </Portal>
+        )}
+      </View>
+    );
+  }
+}

--- a/packages/react-native-oursky-example/src/screens/PortalScreen.js
+++ b/packages/react-native-oursky-example/src/screens/PortalScreen.js
@@ -65,7 +65,7 @@ export default class PortalScreen extends React.PureComponent<{}, State> {
               >
                 <Text>Add 1</Text>
               </TouchableOpacity>
-              <Text>Count in portla: {this.state.count}</Text>
+              <Text>Count in portal: {this.state.count}</Text>
               <TouchableOpacity style={styles.button} onPress={this.hidePortal}>
                 <Text>Close</Text>
               </TouchableOpacity>

--- a/packages/react-native-oursky/index.d.ts
+++ b/packages/react-native-oursky/index.d.ts
@@ -210,3 +210,7 @@ export interface FadeAnimationProps {
   style?: StyleProp<ViewStyle>;
 }
 export class FadeAnimation extends React.Component<FadeAnimationProps> {}
+
+export class PortalHost extends React.Component {}
+export class Portal extends React.Component {}
+

--- a/packages/react-native-oursky/src/Portal/Portal.js
+++ b/packages/react-native-oursky/src/Portal/Portal.js
@@ -1,0 +1,37 @@
+// @flow
+import * as React from "react";
+import { PortalContext } from "./PortalHost";
+import type { PortalMethods } from "./PortalHost";
+
+type Props = {
+  portalMethods: PortalMethods,
+  children: React.Node,
+};
+
+class Portal_ extends React.Component<Props> {
+  key: any;
+
+  componentDidMount() {
+    this.key = this.props.portalMethods.mount(this.props.children);
+  }
+
+  componentDidUpdate() {
+    this.props.portalMethods.update(this.key, this.props.children);
+  }
+
+  componentWillUnmount() {
+    this.props.portalMethods.unmount(this.key);
+  }
+
+  render() {
+    return null;
+  }
+}
+
+export default function Portal(props: { children: React.Node }) {
+  return (
+    <PortalContext.Consumer>
+      {methods => <Portal_ {...props} portalMethods={methods} />}
+    </PortalContext.Consumer>
+  );
+}

--- a/packages/react-native-oursky/src/Portal/PortalHost.js
+++ b/packages/react-native-oursky/src/Portal/PortalHost.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from "react";
+import { StyleSheet, View } from "react-native";
 
 type PortalKey = number;
 type PortalMethods = {
@@ -69,10 +70,24 @@ class PortalHost extends React.Component<Props, State> {
     }));
   };
 
+  renderPortals() {
+    return this.state.portals.map(portal => (
+      <View
+        key={key}
+        style={StyleSheet.absoluteFill}
+        collapsable={false}
+        pointerEvents="box-none"
+      >
+        {portal.children}
+      </View>
+    ));
+  }
+
   render() {
     return (
       <PortalContext.Provider value={this.state.portalMethods}>
         {this.props.children}
+        {this.renderPortals()}
       </PortalContext.Provider>
     );
   }

--- a/packages/react-native-oursky/src/Portal/PortalHost.js
+++ b/packages/react-native-oursky/src/Portal/PortalHost.js
@@ -1,0 +1,81 @@
+// @flow
+import * as React from "react";
+
+type PortalKey = number;
+type PortalMethods = {
+  mount: (children: React.Node) => PortalKey,
+  update: (key: PortalKey, children: React.Node) => void,
+  unmount: (key: PortalKey) => void,
+};
+
+type RenderedPortal = {
+  key: PortalKey,
+  children: React.Node,
+};
+
+type Props = {
+  children: React.Node,
+};
+
+type State = {
+  portalMethods: PortalMethods,
+  portals: RenderedPortal[],
+};
+
+export const PortalContext = React.createContext<PortalMethods>((null: any));
+
+class PortalHost extends React.Component<Props, State> {
+  nextPortalKey = 0;
+  state = {
+    portals: [],
+    portalMethods: {
+      mount: this.mount,
+      update: this.update,
+      unmount: this.unmount,
+    },
+  };
+
+  mount = (children: React.Node): PortalKey => {
+    const portalKey = this.nextPortalKey++;
+    this.setState(prevState => ({
+      portals: [
+        ...prevState.portals,
+        {
+          key: portalKey,
+          children,
+        },
+      ],
+    }));
+    return portalKey;
+  };
+
+  update = (key: PortalKey, children: React.Node) => {
+    this.setState(prevState => ({
+      portals: prevState.portals.map(portal => {
+        if (portal.key === key) {
+          return {
+            key,
+            children,
+          };
+        }
+        return portal;
+      }),
+    }));
+  };
+
+  unmount = (key: PortalKey) => {
+    this.setState(prevState => ({
+      portals: prevState.portals.filter(p => p.key !== key),
+    }));
+  };
+
+  render() {
+    return (
+      <PortalContext.Provider value={this.state.portalMethods}>
+        {this.props.children}
+      </PortalContext.Provider>
+    );
+  }
+}
+
+export default PortalHost;

--- a/packages/react-native-oursky/src/Portal/PortalHost.js
+++ b/packages/react-native-oursky/src/Portal/PortalHost.js
@@ -26,15 +26,18 @@ type State = {
 export const PortalContext = React.createContext<PortalMethods>((null: any));
 
 class PortalHost extends React.Component<Props, State> {
-  nextPortalKey = 0;
-  state = {
-    portals: [],
-    portalMethods: {
-      mount: this.mount,
-      update: this.update,
-      unmount: this.unmount,
-    },
-  };
+  constructor(props: Props) {
+    super(props);
+    this.nextPortalKey = 0;
+    this.state = {
+      portals: [],
+      portalMethods: {
+        mount: this.mount,
+        update: this.update,
+        unmount: this.unmount,
+      },
+    };
+  }
 
   mount = (children: React.Node): PortalKey => {
     const portalKey = this.nextPortalKey++;

--- a/packages/react-native-oursky/src/Portal/PortalHost.js
+++ b/packages/react-native-oursky/src/Portal/PortalHost.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import { StyleSheet, View } from "react-native";
 
 type PortalKey = number;
-type PortalMethods = {
+export type PortalMethods = {
   mount: (children: React.Node) => PortalKey,
   update: (key: PortalKey, children: React.Node) => void,
   unmount: (key: PortalKey) => void,
@@ -73,7 +73,7 @@ class PortalHost extends React.Component<Props, State> {
   renderPortals() {
     return this.state.portals.map(portal => (
       <View
-        key={key}
+        key={portal.key}
         style={StyleSheet.absoluteFill}
         collapsable={false}
         pointerEvents="box-none"

--- a/packages/react-native-oursky/src/Portal/PortalHost.js
+++ b/packages/react-native-oursky/src/Portal/PortalHost.js
@@ -26,6 +26,8 @@ type State = {
 export const PortalContext = React.createContext<PortalMethods>((null: any));
 
 class PortalHost extends React.Component<Props, State> {
+  nextPortalKey: PortalKey;
+
   constructor(props: Props) {
     super(props);
     this.nextPortalKey = 0;

--- a/packages/react-native-oursky/src/Portal/index.js
+++ b/packages/react-native-oursky/src/Portal/index.js
@@ -1,0 +1,2 @@
+export { default as Portal } from "./Portal";
+export { default as PortalHost } from "./PortalHost";

--- a/packages/react-native-oursky/src/index.js
+++ b/packages/react-native-oursky/src/index.js
@@ -25,3 +25,5 @@ export { default as Dialog } from "./Dialog";
 export type { Props as DialogProps } from "./Dialog";
 export { default as RequirePermission } from "./RequirePermission";
 export type { Props as RequirePermissionProps } from "./RequirePermission";
+
+export { Portal, PortalHost } from "./Portal";


### PR DESCRIPTION
The idea is pass the `children` of a component to other component using context. 

Since we cannot randomly create element in react native, this implementation requires user to mount a host component at root level of their app.