### PR TITLE
Fix Android device back button not work in country list

### DIFF
--- a/src/CountryList.tsx
+++ b/src/CountryList.tsx
@@ -183,7 +183,11 @@ export default class CountryList extends React.PureComponent<Props, State> {
       )
       .sort(orderByCallingCodeAndName);
     return (
-      <Modal visible={visible} animationType="slide">
+      <Modal
+        visible={visible}
+        animationType="slide"
+        onRequestClose={onPressBackButton}
+      >
         <SafeAreaView style={defaultStyles.container}>
           <View style={defaultStyles.header}>
             <TouchableOpacity


### PR DESCRIPTION
`BackHandler` events will not be emitted as long as the modal is open, we have to add `onRequestClose` to handle the Android device back button event

Ref: https://facebook.github.io/react-native/docs/modal#onrequestclose