### PR TITLE
Fix createForm type issues

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ import {
   TextStyle,
   ImageSourcePropType,
   ScrollViewProps,
-  TextInputFocusEventData,
+  TextInputSubmitEditingEventData,
   NativeSyntheticEvent,
 } from "react-native";
 
@@ -293,14 +293,18 @@ declare class Form extends React.Component<FormProps> {}
 
 interface FormFieldRenderProps {
   focusableRef: React.Ref<any>;
-  onSubmitEditing: (e: NativeSyntheticEvent<TextInputFocusEventData>) => void;
+  onSubmitEditing: (
+    e: NativeSyntheticEvent<TextInputSubmitEditingEventData>
+  ) => void;
   blurOnSubmit: false;
 }
 
 interface FormFieldProps {
   index: number;
   children: (props: FormFieldRenderProps) => React.ReactNode;
-  onSubmitEditing?: (e: NativeSyntheticEvent<TextInputFocusEventData>) => void;
+  onSubmitEditing?: (
+    e: NativeSyntheticEvent<TextInputSubmitEditingEventData>
+  ) => void;
 }
 
 declare class FormField extends React.Component<FormFieldProps> {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -289,9 +289,7 @@ interface FormProps extends ScrollViewProps {
     }
   ) => number;
 }
-declare class Form extends React.Component<FormProps> {
-  constructor(props: FormProps);
-}
+declare class Form extends React.Component<FormProps> {}
 
 interface FormFieldRenderProps {
   focusableRef: React.Ref<any>;
@@ -305,9 +303,7 @@ interface FormFieldProps {
   onSubmitEditing?: (e: NativeSyntheticEvent<TextInputFocusEventData>) => void;
 }
 
-declare class FormField extends React.Component<FormFieldProps> {
-  constructor(props: FormFieldProps);
-}
+declare class FormField extends React.Component<FormFieldProps> {}
 
 export function createForm(): {
   Form: typeof Form;

--- a/index.d.ts
+++ b/index.d.ts
@@ -289,7 +289,9 @@ interface FormProps extends ScrollViewProps {
     }
   ) => number;
 }
-declare class Form extends React.Component<FormProps> {}
+declare class Form extends React.Component<FormProps> {
+  constructor(props: FormProps);
+}
 
 interface FormFieldRenderProps {
   focusableRef: React.Ref<any>;
@@ -303,9 +305,11 @@ interface FormFieldProps {
   onSubmitEditing?: (e: NativeSyntheticEvent<TextInputFocusEventData>) => void;
 }
 
-declare class FormField extends React.Component<FormFieldProps> {}
+declare class FormField extends React.Component<FormFieldProps> {
+  constructor(props: FormFieldProps);
+}
 
 export function createForm(): {
-  Form: Form;
-  FormField: FormField;
+  Form: typeof Form;
+  FormField: typeof FormField;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -280,7 +280,7 @@ export class Picker extends React.Component<PickerProps> {}
 
 interface FormProps extends ScrollViewProps {
   autoScrollToFocusedInput?: boolean;
-  scrollToInputThresholds: number;
+  scrollToInputThresholds?: number;
   getScrollToTextInputOffset?: (
     data: {
       inputY: number;

--- a/src/Form/createForm.tsx
+++ b/src/Form/createForm.tsx
@@ -9,9 +9,9 @@ import {
   ScrollView,
   ScrollViewProps,
   TextInput,
-  TextInputFocusEventData,
   UIManager,
   View,
+  TextInputSubmitEditingEventData,
 } from "react-native";
 
 interface FocusableContainer {
@@ -47,14 +47,18 @@ interface FormProps extends ScrollViewProps {
 
 interface FormFieldRenderProps {
   focusableRef: React.Ref<any>;
-  onSubmitEditing: (e: NativeSyntheticEvent<TextInputFocusEventData>) => void;
+  onSubmitEditing: (
+    e: NativeSyntheticEvent<TextInputSubmitEditingEventData>
+  ) => void;
   blurOnSubmit: false;
 }
 
 interface FormFieldProps {
   index: number;
   children: (props: FormFieldRenderProps) => React.ReactNode;
-  onSubmitEditing: (e: NativeSyntheticEvent<TextInputFocusEventData>) => void;
+  onSubmitEditing?: (
+    e: NativeSyntheticEvent<TextInputSubmitEditingEventData>
+  ) => void;
 }
 
 const defaultFormContextValue = {
@@ -334,7 +338,9 @@ export default function createForm() {
       this.props.setFieldInstance(this.props.index, null);
     }
 
-    onSubmitEditing = (e: NativeSyntheticEvent<TextInputFocusEventData>) => {
+    onSubmitEditing = (
+      e: NativeSyntheticEvent<TextInputSubmitEditingEventData>
+    ) => {
       this.props.focusNext(this.props.index);
       if (this.props.onSubmitEditing != null) {
         this.props.onSubmitEditing(e);


### PR DESCRIPTION
Fixing 2 issues related to `createForm()`:

1. The return type should be the classes `FormField` and `Form` rather than their instances.
2. `onSubmitEditing` of React components like `TextInput` is of type 
`(e: NativeSyntheticEvent<TextInputSubmitEditingEventData>) => void;`. So I think we should have the same type in  `createForm()`.