### PR TITLE
Implement picker styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,31 @@ git commit
 git push <your-remote> <your-branch>
 ```
 
+## How to Run Example Project in iOS
+
+After cloning the proejct fresh, run :
+
+```sh
+yarn install
+cd example
+yarn install
+```
+
+Then in `/example/node_modules/react-native/React/Base/RCTModuleMethod.mm`, find method `RCTParseUnused`
+add the line :`RCTReadString(input, "__attribute__((__unused__))") ||` after `return RCTReadString(input, "__unused") ||`
+the method should become:
+
+```
+static BOOL RCTParseUnused(const char **input)
+{
+  return RCTReadString(input, "__unused") ||
+         RCTReadString(input, "__attribute__((__unused__))") ||
+         RCTReadString(input, "__attribute__((unused))");
+}
+```
+
+then the example project can be compiled.
+
 ## Principle
 
 - Written in TypeScript

--- a/example/src/screens/PickerScreen.js
+++ b/example/src/screens/PickerScreen.js
@@ -70,6 +70,11 @@ export default class PortalScreen extends React.PureComponent<{}, State> {
           onDismiss={this.onDismiss}
           onDone={this.onDone}
           onCancel={this.onCancel}
+          toolbarStyle={{ backgroundColor: "rgb(72,72,74)" }}
+          itemsStyle={{
+            backgroundColor: "rgb(58,58,60)",
+            color: "rgb(242,242,247)",
+          }}
         />
       </View>
     );

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ import {
   ScrollViewProps,
   TextInputSubmitEditingEventData,
   NativeSyntheticEvent,
+  StyleProp,
 } from "react-native";
 
 export type AndroidKeyboardDidHideEvent = null | undefined;
@@ -74,6 +75,8 @@ export interface PickerProps {
   doneButtonLabel?: string;
   cancelButtonLabel?: string | null;
   ToolbarComponent?: React.ReactType<{}>;
+  toolbarStyle?: StyleProp<ViewStyle>;
+  itemsStyle?: StyleProp<ViewStyle>;
 }
 
 export class Picker extends React.Component<PickerProps> {}

--- a/src/Picker.tsx
+++ b/src/Picker.tsx
@@ -6,6 +6,8 @@ import {
   View,
   TouchableOpacity,
   Text,
+  StyleProp,
+  ViewStyle,
 } from "react-native";
 import DialogAndroid, { OptionsPicker } from "react-native-dialogs";
 import Modal from "./Modal";
@@ -27,6 +29,8 @@ export interface Props {
   doneButtonLabel?: string;
   cancelButtonLabel?: string | null;
   ToolbarComponent?: React.ReactType<{}>;
+  toolbarStyle?: StyleProp<ViewStyle>;
+  itemsStyle?: StyleProp<ViewStyle>;
 }
 
 interface State {
@@ -63,6 +67,7 @@ class ToolbarIOS extends React.Component<{
   doneButtonLabel?: string;
   onDonePress: () => void;
   onCancelPress: () => void;
+  toolbarStyle?: StyleProp<ViewStyle>;
 }> {
   render() {
     let {
@@ -70,6 +75,7 @@ class ToolbarIOS extends React.Component<{
       doneButtonLabel,
       onDonePress,
       onCancelPress,
+      toolbarStyle,
     } = this.props;
     let justifyContent: any = "";
     if (cancelButtonLabel === null && doneButtonLabel !== null) {
@@ -85,7 +91,7 @@ class ToolbarIOS extends React.Component<{
       doneButtonLabel = "Done";
     }
     return (
-      <View style={[styles.toolbar, { justifyContent }]}>
+      <View style={[styles.toolbar, { justifyContent }, toolbarStyle]}>
         {typeof cancelButtonLabel === "string" ? (
           <TouchableOpacity
             style={styles.toolbarButton}
@@ -171,6 +177,8 @@ class PickerImplIOS extends React.Component<Props, State> {
       cancelButtonLabel,
       doneButtonLabel,
       ToolbarComponent,
+      toolbarStyle,
+      itemsStyle,
     } = this.props;
     const { selectedValue } = this.state;
     return (
@@ -184,11 +192,13 @@ class PickerImplIOS extends React.Component<Props, State> {
               doneButtonLabel={doneButtonLabel}
               onDonePress={this.onDonePress}
               onCancelPress={this.onCancelPress}
+              toolbarStyle={toolbarStyle}
             />
           )}
           <PickerIOS
             selectedValue={selectedValue}
             onValueChange={this.onValueChange}
+            itemStyle={itemsStyle}
           >
             {items.map(this.renderItem)}
           </PickerIOS>


### PR DESCRIPTION
Implement styling props for `<Picker>`

`<Picker>`'s toolbar and items can now be styled like 
```
        <Picker
          visible={visible}
          value={selectedValue}
          items={ITEMS}
          onDismiss={this.onDismiss}
          onDone={this.onDone}
          onCancel={this.onCancel}
          toolbarStyle={{ backgroundColor: "rgb(72,72,74)" }}
          itemsStyle={{
            backgroundColor: "rgb(58,58,60)",
            color: "rgb(242,242,247)",
          }}
        />
```