### PR TITLE
Load PickerIOS from react-native-picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "peerDependencies": {
     "react": ">=16.3",
     "react-native": ">=0.50",
-    "react-native-dialogs": "^1.0.0"
+    "react-native-dialogs": "^1.0.0",
+    "@react-native-picker/picker": "^2.4.8"
   },
   "devDependencies": {
     "@oursky/react-native-javascript-environment-typescript": "0.1.0",
@@ -35,5 +36,8 @@
     "rollup-plugin-typescript": "1.0.0",
     "tslib": "1.9.3",
     "typescript": "3.2.2"
+  },
+  "dependencies": {
+    "@react-native-picker/picker": "^2.4.8"
   }
 }

--- a/src/Picker.tsx
+++ b/src/Picker.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import {
   Platform,
-  PickerIOS,
   StyleSheet,
   View,
   TouchableOpacity,
@@ -9,6 +8,7 @@ import {
   StyleProp,
   ViewStyle,
 } from "react-native";
+import {PickerIOS} from "@react-native-picker/picker"
 import DialogAndroid, { OptionsPicker } from "react-native-dialogs";
 import Modal from "./Modal";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,6 +652,11 @@
   resolved "https://registry.yarnpkg.com/@oursky/react-native-javascript-environment-typescript/-/react-native-javascript-environment-typescript-0.1.0.tgz#585575f0ec2ab89f3deba1227a3209ce855fcdec"
   integrity sha512-xhxiSNy/xOkXJk7liuzATGNCVIlJD/D24kNCBsyPuzUOH96QBK7rm5F5BrZ0XbIEHSci82pleQjVTZbiTafwwQ==
 
+"@react-native-picker/picker@^2.4.8":
+  version "2.4.8"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.4.8.tgz#a1a21f3d6ecadedbc3f0b691a444ddd7baa081f8"
+  integrity sha512-5NQ5XPo1B03YNqKFrV6h9L3CQaHlB80wd4ETHUEABRP2iLh7FHLVObX2GfziD+K/VJb8G4KZcZ23NFBFP1f7bg==
+
 "@react-navigation/core@3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-3.0.1.tgz#9c513c65ae64aa8dee2777f66f547d488905140b"


### PR DESCRIPTION
Fix `Picker has been removed from React Native` error